### PR TITLE
Config as scriptableobject

### DIFF
--- a/Assets/AnimationImporter/Editor/AnimationAssetPostProcessor.cs
+++ b/Assets/AnimationImporter/Editor/AnimationAssetPostProcessor.cs
@@ -25,9 +25,16 @@ namespace AnimationImporter
 				return;
 			}
 
+			// Do not create shared config during AssetPostprocess, or else it will recreate an empty config
 			importer.LoadUserConfig();
 
-			if (importer.automaticImporting)
+			// If no config exists, they can't have set up automatic importing so just return out.
+			if (importer.sharedData == null)
+			{
+				return;
+			}
+
+			if (importer.sharedData.automaticImporting)
 			{
 				List<string> markedAssets = new List<string>();
 

--- a/Assets/AnimationImporter/Editor/AnimationImporter.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporter.cs
@@ -124,9 +124,9 @@ namespace AnimationImporter
 
 		private void LoadPreferences()
 		{
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "asepritePath"))
+			if (PlayerPrefs.HasKey(PREFS_PREFIX + "asepritePath"))
 			{
-				_asepritePath = EditorPrefs.GetString(PREFS_PREFIX + "asepritePath");
+				_asepritePath = PlayerPrefs.GetString(PREFS_PREFIX + "asepritePath");
 			}
 			else
 			{
@@ -136,9 +136,9 @@ namespace AnimationImporter
 					_asepritePath = "";
 			}
 
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "baseControllerPath"))
+			if (PlayerPrefs.HasKey(PREFS_PREFIX + "baseControllerPath"))
 			{
-				string baseControllerPath = EditorPrefs.GetString(PREFS_PREFIX + "baseControllerPath");
+				string baseControllerPath = PlayerPrefs.GetString(PREFS_PREFIX + "baseControllerPath");
 				if (!string.IsNullOrEmpty(baseControllerPath))
 				{
 					_baseController = AssetDatabase.LoadAssetAtPath<RuntimeAnimatorController>(baseControllerPath);
@@ -150,15 +150,15 @@ namespace AnimationImporter
 
 		private void SaveUserConfig()
 		{
-			EditorPrefs.SetString(PREFS_PREFIX + "asepritePath", _asepritePath);
+			PlayerPrefs.SetString(PREFS_PREFIX + "asepritePath", _asepritePath);
 
 			if (_baseController != null)
 			{
-				EditorPrefs.SetString(PREFS_PREFIX + "baseControllerPath", AssetDatabase.GetAssetPath(_baseController));
+				PlayerPrefs.SetString(PREFS_PREFIX + "baseControllerPath", AssetDatabase.GetAssetPath(_baseController));
 			}
 			else
 			{
-				EditorPrefs.SetString(PREFS_PREFIX + "baseControllerPath", "");
+				PlayerPrefs.SetString(PREFS_PREFIX + "baseControllerPath", "");
 			}
 		}
 

--- a/Assets/AnimationImporter/Editor/AnimationImporter.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporter.cs
@@ -32,6 +32,7 @@ namespace AnimationImporter
 		// --------------------------------------------------------------------------------
 
 		private const string PREFS_PREFIX = "ANIMATION_IMPORTER_";
+		private const string SHARED_CONFIG_PATH = "Assets/Resources/AnimationImporter/AnimationImporterConfig.asset";
 
 		private static string[] allowedExtensions = { "ase" };
 
@@ -57,92 +58,6 @@ namespace AnimationImporter
 			}
 		}
 
-		// sprite import values
-		private float _spritePixelsPerUnit = 100f;
-		public float spritePixelsPerUnit
-		{
-			get
-			{
-				return _spritePixelsPerUnit;
-			}
-			set
-			{
-				if (_spritePixelsPerUnit != value)
-				{
-					_spritePixelsPerUnit = value;
-					SaveUserConfig();
-				}
-			}
-		}
-
-		private AnimationTargetObjectType _targetObjectType = AnimationTargetObjectType.SpriteRenderer;
-		public AnimationTargetObjectType targetObjectType
-		{
-			get
-			{
-				return _targetObjectType;
-			}
-			set
-			{
-				if (_targetObjectType != value)
-				{
-					_targetObjectType = value;
-					SaveUserConfig();
-				}
-			}
-		}
-
-		private SpriteAlignment _spriteAlignment = SpriteAlignment.BottomCenter;
-		public SpriteAlignment spriteAlignment
-		{
-			get
-			{
-				return _spriteAlignment;
-			}
-			set
-			{
-				if (_spriteAlignment != value)
-				{
-					_spriteAlignment = value;
-					SaveUserConfig();
-				}
-			}
-		}
-
-		private float _spriteAlignmentCustomX = 0;
-		public float spriteAlignmentCustomX
-		{
-			get
-			{
-				return _spriteAlignmentCustomX;
-			}
-			set
-			{
-				if (_spriteAlignmentCustomX != value)
-				{
-					_spriteAlignmentCustomX = value;
-					SaveUserConfig();
-				}
-			}
-		}
-
-		private float _spriteAlignmentCustomY = 0;
-		public float spriteAlignmentCustomY
-		{
-			get
-			{
-				return _spriteAlignmentCustomY;
-			}
-			set
-			{
-				if (_spriteAlignmentCustomY != value)
-				{
-					_spriteAlignmentCustomY = value;
-					SaveUserConfig();
-				}
-			}
-		}
-
 		private RuntimeAnimatorController _baseController = null;
 		public RuntimeAnimatorController baseController
 		{
@@ -160,58 +75,14 @@ namespace AnimationImporter
 			}
 		}
 
-		private bool _saveSpritesToSubfolder = true;
-		public bool saveSpritesToSubfolder
+		private AnimationImporterSharedConfig _sharedData;
+		public AnimationImporterSharedConfig sharedData 
 		{
 			get
 			{
-				return _saveSpritesToSubfolder;
-			}
-			set
-			{
-				if (_saveSpritesToSubfolder != value)
-				{
-					_saveSpritesToSubfolder = value;
-					SaveUserConfig();
-				}
+				return _sharedData;
 			}
 		}
-		private bool _saveAnimationsToSubfolder = true;
-		public bool saveAnimationsToSubfolder
-		{
-			get
-			{
-				return _saveAnimationsToSubfolder;
-			}
-			set
-			{
-				if (_saveAnimationsToSubfolder != value)
-				{
-					_saveAnimationsToSubfolder = value;
-					SaveUserConfig();
-				}
-			}
-		}
-
-		private bool _automaticImporting = false;
-		public bool automaticImporting
-		{
-			get
-			{
-				return _automaticImporting;
-			}
-			set
-			{
-				if (_automaticImporting != value)
-				{
-					_automaticImporting = value;
-					SaveUserConfig();
-				}
-			}
-		}
-
-		private List<string> _animationNamesThatDoNotLoop = new List<string>() { "death" };
-		public List<string> animationNamesThatDoNotLoop { get { return _animationNamesThatDoNotLoop; } }
 
 		// ================================================================================
 		//  private
@@ -237,7 +108,21 @@ namespace AnimationImporter
 		//  save and load user values
 		// --------------------------------------------------------------------------------
 
+		public void LoadOrCreateUserConfig()
+		{
+			LoadPreferences();
+
+			_sharedData = ScriptableObjectUtility.LoadOrCreateSaveData<AnimationImporterSharedConfig>(SHARED_CONFIG_PATH);
+		}
+
 		public void LoadUserConfig()
+		{
+			LoadPreferences();
+
+			_sharedData = ScriptableObjectUtility.LoadSaveData<AnimationImporterSharedConfig>(SHARED_CONFIG_PATH);
+		}
+
+		private void LoadPreferences()
 		{
 			if (EditorPrefs.HasKey(PREFS_PREFIX + "asepritePath"))
 			{
@@ -251,61 +136,12 @@ namespace AnimationImporter
 					_asepritePath = "";
 			}
 
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spritePixelsPerUnit"))
-			{
-				_spritePixelsPerUnit = EditorPrefs.GetFloat(PREFS_PREFIX + "spritePixelsPerUnit");
-			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteTargetObjectType"))
-			{
-				_targetObjectType = (AnimationTargetObjectType)EditorPrefs.GetInt(PREFS_PREFIX + "spriteTargetObjectType");
-			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignment"))
-			{
-				_spriteAlignment = (SpriteAlignment)EditorPrefs.GetInt(PREFS_PREFIX + "spriteAlignment");
-			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignmentCustomX"))
-			{
-				_spriteAlignmentCustomX = EditorPrefs.GetFloat(PREFS_PREFIX + "spriteAlignmentCustomX");
-			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignmentCustomY"))
-			{
-				_spriteAlignmentCustomY = EditorPrefs.GetFloat(PREFS_PREFIX + "spriteAlignmentCustomY");
-			}
-
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "saveSpritesToSubfolder"))
-			{
-				_saveSpritesToSubfolder = EditorPrefs.GetBool(PREFS_PREFIX + "saveSpritesToSubfolder");
-			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "saveAnimationsToSubfolder"))
-			{
-				_saveAnimationsToSubfolder = EditorPrefs.GetBool(PREFS_PREFIX + "saveAnimationsToSubfolder");
-			}
-
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "automaticImporting"))
-			{
-				_automaticImporting = EditorPrefs.GetBool(PREFS_PREFIX + "automaticImporting");
-			}
-
 			if (EditorPrefs.HasKey(PREFS_PREFIX + "baseControllerPath"))
 			{
 				string baseControllerPath = EditorPrefs.GetString(PREFS_PREFIX + "baseControllerPath");
 				if (!string.IsNullOrEmpty(baseControllerPath))
 				{
 					_baseController = AssetDatabase.LoadAssetAtPath<RuntimeAnimatorController>(baseControllerPath);
-				}
-			}
-
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "nonLoopCount"))
-			{
-				_animationNamesThatDoNotLoop = new List<string>();
-				int count = EditorPrefs.GetInt(PREFS_PREFIX + "nonLoopCount");
-
-				for (int i = 0; i < count; i++)
-				{
-					if (EditorPrefs.HasKey(PREFS_PREFIX + "nonLoopCount" + i.ToString()))
-					{
-						_animationNamesThatDoNotLoop.Add(EditorPrefs.GetString(PREFS_PREFIX + "nonLoopCount" + i.ToString()));
-					}
 				}
 			}
 
@@ -316,17 +152,6 @@ namespace AnimationImporter
 		{
 			EditorPrefs.SetString(PREFS_PREFIX + "asepritePath", _asepritePath);
 
-			EditorPrefs.SetFloat(PREFS_PREFIX + "spritePixelsPerUnit", _spritePixelsPerUnit);
-			EditorPrefs.SetInt(PREFS_PREFIX + "spriteTargetObjectType", (int)_targetObjectType);
-			EditorPrefs.SetInt(PREFS_PREFIX + "spriteAlignment", (int)_spriteAlignment);
-			EditorPrefs.SetFloat(PREFS_PREFIX + "spriteAlignmentCustomX", _spriteAlignmentCustomX);
-			EditorPrefs.SetFloat(PREFS_PREFIX + "spriteAlignmentCustomY", _spriteAlignmentCustomY);
-
-			EditorPrefs.SetBool(PREFS_PREFIX + "saveSpritesToSubfolder", _saveSpritesToSubfolder);
-			EditorPrefs.SetBool(PREFS_PREFIX + "saveAnimationsToSubfolder", _saveAnimationsToSubfolder);
-
-			EditorPrefs.SetBool(PREFS_PREFIX + "automaticImporting", _automaticImporting);
-
 			if (_baseController != null)
 			{
 				EditorPrefs.SetString(PREFS_PREFIX + "baseControllerPath", AssetDatabase.GetAssetPath(_baseController));
@@ -335,29 +160,6 @@ namespace AnimationImporter
 			{
 				EditorPrefs.SetString(PREFS_PREFIX + "baseControllerPath", "");
 			}
-
-			EditorPrefs.SetInt(PREFS_PREFIX + "nonLoopCount", _animationNamesThatDoNotLoop.Count);
-			for (int i = 0; i < _animationNamesThatDoNotLoop.Count; i++)
-			{
-				EditorPrefs.SetString(PREFS_PREFIX + "nonLoopCount" + i.ToString(), _animationNamesThatDoNotLoop[i]);
-			}
-		}
-
-		public void RemoveAnimationThatDoesNotLoop(int index)
-		{
-			_animationNamesThatDoNotLoop.RemoveAt(index);
-			SaveUserConfig();
-		}
-
-		public bool AddAnimationThatDoesNotLoop(string animationName)
-		{
-			if (string.IsNullOrEmpty(animationName) || _animationNamesThatDoNotLoop.Contains(animationName))
-				return false;
-
-			_animationNamesThatDoNotLoop.Add(animationName);
-			SaveUserConfig();
-
-			return true;
 		}
 
 		// ================================================================================
@@ -422,7 +224,7 @@ namespace AnimationImporter
 			// we analyze import settings on existing files
 			PreviousImportSettings previousAnimationInfo = CollectPreviousImportSettings(basePath, name);
 
-			if (AsepriteImporter.CreateSpriteAtlasAndMetaFile(_asepritePath, basePath, name, _saveSpritesToSubfolder))
+			if (AsepriteImporter.CreateSpriteAtlasAndMetaFile(_asepritePath, basePath, name, _sharedData.saveSpritesToSubfolder))
 			{
 				AssetDatabase.Refresh();
 				return ImportJSONAndCreateAnimations(basePath, name, previousAnimationInfo);
@@ -528,7 +330,7 @@ namespace AnimationImporter
 
 				animationInfo.basePath = basePath;
 				animationInfo.name = name;
-				animationInfo.nonLoopingAnimations = _animationNamesThatDoNotLoop;
+				animationInfo.nonLoopingAnimations = sharedData.animationNamesThatDoNotLoop;
 
 				// delete JSON file afterwards
 				AssetDatabase.DeleteAsset(AssetDatabase.GetAssetPath(textAsset));
@@ -551,7 +353,7 @@ namespace AnimationImporter
 		{
 			if (animationInfo.hasAnimations)
 			{
-				if (_saveAnimationsToSubfolder)
+				if (sharedData.saveAnimationsToSubfolder)
 				{
 					string path = animationInfo.basePath + "/Animations";
 					if (!Directory.Exists(path))
@@ -589,7 +391,7 @@ namespace AnimationImporter
 
 			foreach (var animation in animationInfo.animations)
 			{
-				animationInfo.CreateAnimation(animation, sprites, pathForAnimations, masterName, targetObjectType);
+				animationInfo.CreateAnimation(animation, sprites, pathForAnimations, masterName, sharedData.targetObjectType);
 			}
 		}
 
@@ -601,14 +403,17 @@ namespace AnimationImporter
 			if (!animations.hasPreviousTextureImportSettings)
 			{
 				importer.textureType = TextureImporterType.Sprite;
-				importer.spritePixelsPerUnit = _spritePixelsPerUnit;
+				importer.spritePixelsPerUnit = sharedData.spritePixelsPerUnit;
 				importer.mipmapEnabled = false;
 				importer.filterMode = FilterMode.Point;
 				importer.textureFormat = TextureImporterFormat.AutomaticTruecolor;
 			}
 
 			// create sub sprites for this file according to the AsepriteAnimationInfo 
-			importer.spritesheet = animations.GetSpriteSheet(_spriteAlignment, _spriteAlignmentCustomX, _spriteAlignmentCustomY);
+			importer.spritesheet = animations.GetSpriteSheet(
+				sharedData.spriteAlignment,
+				sharedData.spriteAlignmentCustomX,
+				sharedData.spriteAlignmentCustomY);
 
 			// reapply old import settings (pivot settings for sprites)
 			if (animations.hasPreviousTextureImportSettings)
@@ -668,7 +473,7 @@ namespace AnimationImporter
 
 		private string GetImageAssetFilename(string basePath, string name)
 		{
-			if (_saveSpritesToSubfolder)
+			if (sharedData.saveSpritesToSubfolder)
 				basePath += "/Sprites";
 
 			return basePath + "/" + name + ".png";
@@ -676,7 +481,7 @@ namespace AnimationImporter
 
 		private string GetJSONAssetFilename(string basePath, string name)
 		{
-			if (_saveSpritesToSubfolder)
+			if (sharedData.saveSpritesToSubfolder)
 				basePath += "/Sprites";
 
 			return basePath + "/" + name + ".json";

--- a/Assets/AnimationImporter/Editor/AnimationImporterShaderConfigEditor.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporterShaderConfigEditor.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace AnimationImporter
+{
+	[CustomEditor(typeof(AnimationImporterSharedConfig))]
+	public class AnimationImporterShaderConfigEditor : Editor
+	{
+		public override void OnInspectorGUI ()
+		{
+			GUI.enabled = false;
+			base.OnInspectorGUI ();
+			GUI.enabled = true;
+		}
+	}
+}

--- a/Assets/AnimationImporter/Editor/AnimationImporterShaderConfigEditor.cs.meta
+++ b/Assets/AnimationImporter/Editor/AnimationImporterShaderConfigEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 859b62f90389442268f25da51b3944a5
+timeCreated: 1469682923
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnimationImporter/Editor/AnimationImporterSharedConfig.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporterSharedConfig.cs
@@ -147,7 +147,8 @@ namespace AnimationImporter
 		/// <returns><c>true</c>, if the user has old preferences, <c>false</c> otherwise.</returns>
 		public bool UserHasOldPreferences()
 		{
-			return EditorPrefs.HasKey(PREFS_PREFIX + "spritePixelsPerUnit");
+			var pixelsPerUnityKey = PREFS_PREFIX + "spritePixelsPerUnit";
+			return PlayerPrefs.HasKey(pixelsPerUnityKey) || EditorPrefs.HasKey(pixelsPerUnityKey);
 		}
 
 		/// <summary>
@@ -155,46 +156,46 @@ namespace AnimationImporter
 		/// </summary>
 		public void CopyFromPreferences()
 		{
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spritePixelsPerUnit"))
+			if (HasKeyInPreferences(PREFS_PREFIX + "spritePixelsPerUnit"))
 			{
-				_spritePixelsPerUnit = EditorPrefs.GetFloat(PREFS_PREFIX + "spritePixelsPerUnit");
+				_spritePixelsPerUnit = GetFloatFromPreferences(PREFS_PREFIX + "spritePixelsPerUnit");
 			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteTargetObjectType"))
+			if (HasKeyInPreferences(PREFS_PREFIX + "spriteTargetObjectType"))
 			{
-				_targetObjectType = (AnimationTargetObjectType)EditorPrefs.GetInt(PREFS_PREFIX + "spriteTargetObjectType");
+				_targetObjectType = (AnimationTargetObjectType)GetIntFromPreferences(PREFS_PREFIX + "spriteTargetObjectType");
 			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignment"))
+			if (HasKeyInPreferences(PREFS_PREFIX + "spriteAlignment"))
 			{
-				_spriteAlignment = (SpriteAlignment)EditorPrefs.GetInt(PREFS_PREFIX + "spriteAlignment");
+				_spriteAlignment = (SpriteAlignment)GetIntFromPreferences(PREFS_PREFIX + "spriteAlignment");
 			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignmentCustomX"))
+			if (HasKeyInPreferences(PREFS_PREFIX + "spriteAlignmentCustomX"))
 			{
-				_spriteAlignmentCustomX = EditorPrefs.GetFloat(PREFS_PREFIX + "spriteAlignmentCustomX");
+				_spriteAlignmentCustomX = GetFloatFromPreferences(PREFS_PREFIX + "spriteAlignmentCustomX");
 			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignmentCustomY"))
+			if (HasKeyInPreferences(PREFS_PREFIX + "spriteAlignmentCustomY"))
 			{
-				_spriteAlignmentCustomY = EditorPrefs.GetFloat(PREFS_PREFIX + "spriteAlignmentCustomY");
+				_spriteAlignmentCustomY = GetFloatFromPreferences(PREFS_PREFIX + "spriteAlignmentCustomY");
 			}
 
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "saveSpritesToSubfolder"))
+			if (HasKeyInPreferences(PREFS_PREFIX + "saveSpritesToSubfolder"))
 			{
-				_saveSpritesToSubfolder = EditorPrefs.GetBool(PREFS_PREFIX + "saveSpritesToSubfolder");
+				_saveSpritesToSubfolder = GetBoolFromPreferences(PREFS_PREFIX + "saveSpritesToSubfolder");
 			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "saveAnimationsToSubfolder"))
+			if (HasKeyInPreferences(PREFS_PREFIX + "saveAnimationsToSubfolder"))
 			{
-				_saveAnimationsToSubfolder = EditorPrefs.GetBool(PREFS_PREFIX + "saveAnimationsToSubfolder");
+				_saveAnimationsToSubfolder = GetBoolFromPreferences(PREFS_PREFIX + "saveAnimationsToSubfolder");
 			}
-			if (EditorPrefs.HasKey(PREFS_PREFIX + "automaticImporting"))
+			if (HasKeyInPreferences(PREFS_PREFIX + "automaticImporting"))
 			{
-				_automaticImporting = EditorPrefs.GetBool(PREFS_PREFIX + "automaticImporting");
+				_automaticImporting = GetBoolFromPreferences(PREFS_PREFIX + "automaticImporting");
 			}
 
 			// Find all nonLoopingClip Prefences, load them into the sharedData.
 			int numOldClips = 0;
 			string loopCountKey = PREFS_PREFIX + "nonLoopCount";
-			if (EditorPrefs.HasKey(loopCountKey))
+			if (HasKeyInPreferences(loopCountKey))
 			{
-				numOldClips = EditorPrefs.GetInt(loopCountKey);
+				numOldClips = GetIntFromPreferences(loopCountKey);
 			}
 
 			for (int i = 0; i < numOldClips; ++i)
@@ -202,14 +203,83 @@ namespace AnimationImporter
 				string clipKey = PREFS_PREFIX + "nonLoopCount" + i.ToString();
 
 				// If the clip hasn't already been moved to the shared data, do it now.
-				if (EditorPrefs.HasKey(clipKey))
+				if (HasKeyInPreferences(clipKey))
 				{
-					var stringAtKey = EditorPrefs.GetString(clipKey);
+					var stringAtKey = GetStringFromPreferences(clipKey);
 					if (!_animationNamesThatDoNotLoop.Contains(stringAtKey))
 					{
 						_animationNamesThatDoNotLoop.Add(stringAtKey);
 					}
 				}
+			}
+		}
+
+		private bool HasKeyInPreferences(string key)
+		{
+			return PlayerPrefs.HasKey(key) || EditorPrefs.HasKey(key);
+		}
+
+		private int GetIntFromPreferences(string intKey)
+		{
+			if (PlayerPrefs.HasKey(intKey))
+			{
+				return PlayerPrefs.GetInt(intKey);
+			}
+			else if (EditorPrefs.HasKey(intKey))
+			{
+				return EditorPrefs.GetInt(intKey);
+			}
+			else
+			{
+				return int.MinValue;
+			}
+		}
+
+		private float GetFloatFromPreferences(string floatKey)
+		{
+			if (PlayerPrefs.HasKey(floatKey))
+			{
+				return PlayerPrefs.GetFloat(floatKey);
+			}
+			else if (EditorPrefs.HasKey(floatKey))
+			{
+				return EditorPrefs.GetFloat(floatKey);
+			}
+			else
+			{
+				return float.NaN;
+			}
+		}
+
+		private bool GetBoolFromPreferences(string boolKey)
+		{
+			if (PlayerPrefs.HasKey(boolKey))
+			{
+				return System.Convert.ToBoolean(PlayerPrefs.GetInt(boolKey));
+			}
+			else if (EditorPrefs.HasKey(boolKey))
+			{
+				return EditorPrefs.GetBool(boolKey);
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		private string GetStringFromPreferences(string stringKey)
+		{
+			if (PlayerPrefs.HasKey(stringKey))
+			{
+				return PlayerPrefs.GetString(stringKey);
+			}
+			else if (EditorPrefs.HasKey(stringKey))
+			{
+				return EditorPrefs.GetString(stringKey);
+			}
+			else
+			{
+				return string.Empty;
 			}
 		}
 	}

--- a/Assets/AnimationImporter/Editor/AnimationImporterSharedConfig.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporterSharedConfig.cs
@@ -1,0 +1,216 @@
+﻿using UnityEditor;
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace AnimationImporter
+{
+	public class AnimationImporterSharedConfig : ScriptableObject
+	{
+		private const string PREFS_PREFIX = "ANIMATION_IMPORTER_";
+
+		[SerializeField]
+		private List<string> _animationNamesThatDoNotLoop = new List<string>() { "death" };
+		public List<string> animationNamesThatDoNotLoop { get { return _animationNamesThatDoNotLoop; } }
+
+		[SerializeField]
+		private bool _automaticImporting = false;
+
+		public bool automaticImporting
+		{
+			get
+			{
+				return _automaticImporting;
+			}
+			set
+			{
+				_automaticImporting = value;
+			}
+		}
+
+		// sprite import values
+		[SerializeField]
+		private float _spritePixelsPerUnit = 100f;
+		public float spritePixelsPerUnit
+		{
+			get
+			{
+				return _spritePixelsPerUnit;
+			}
+			set
+			{
+				_spritePixelsPerUnit = value;
+			}
+		}
+
+		[SerializeField]
+		private AnimationTargetObjectType _targetObjectType = AnimationTargetObjectType.SpriteRenderer;
+		public AnimationTargetObjectType targetObjectType
+		{
+			get
+			{
+				return _targetObjectType;
+			}
+			set
+			{
+				_targetObjectType = value;
+			}
+		}
+
+		[SerializeField]
+		private SpriteAlignment _spriteAlignment = SpriteAlignment.BottomCenter;
+		public SpriteAlignment spriteAlignment
+		{
+			get
+			{
+				return _spriteAlignment;
+			}
+			set
+			{
+				_spriteAlignment = value;
+			}
+		}
+
+		[SerializeField]
+		private float _spriteAlignmentCustomX = 0;
+		public float spriteAlignmentCustomX
+		{
+			get
+			{
+				return _spriteAlignmentCustomX;
+			}
+			set
+			{
+				_spriteAlignmentCustomX = value;
+			}
+		}
+
+		[SerializeField]
+		private float _spriteAlignmentCustomY = 0;
+		public float spriteAlignmentCustomY
+		{
+			get
+			{
+				return _spriteAlignmentCustomY;
+			}
+			set
+			{
+				_spriteAlignmentCustomY = value;
+			}
+		}
+
+		[SerializeField]
+		private bool _saveSpritesToSubfolder = true;
+		public bool saveSpritesToSubfolder
+		{
+			get
+			{
+				return _saveSpritesToSubfolder;
+			}
+			set
+			{
+				_saveSpritesToSubfolder = value;
+			}
+		}
+
+		[SerializeField]
+		private bool _saveAnimationsToSubfolder = true;
+		public bool saveAnimationsToSubfolder
+		{
+			get
+			{
+				return _saveAnimationsToSubfolder;
+			}
+			set
+			{
+				_saveAnimationsToSubfolder = value;
+			}
+		}
+
+		public void RemoveAnimationThatDoesNotLoop(int index)
+		{
+			animationNamesThatDoNotLoop.RemoveAt(index);
+		}
+
+		public bool AddAnimationThatDoesNotLoop(string animationName)
+		{
+			if (string.IsNullOrEmpty(animationName) || animationNamesThatDoNotLoop.Contains(animationName))
+				return false;
+
+			animationNamesThatDoNotLoop.Add(animationName);
+
+			return true;
+		}
+
+		/// <summary>
+		/// Specify if the Unity user has preferences for an older version of AnimationImporter
+		/// </summary>
+		/// <returns><c>true</c>, if the user has old preferences, <c>false</c> otherwise.</returns>
+		public bool UserHasOldPreferences()
+		{
+			return EditorPrefs.HasKey(PREFS_PREFIX + "spritePixelsPerUnit");
+		}
+
+		/// <summary>
+		/// Copies shared data in from Preferences, used to upgrade versions of AnimationImporter
+		/// </summary>
+		public void CopyFromPreferences()
+		{
+			if (EditorPrefs.HasKey(PREFS_PREFIX + "spritePixelsPerUnit"))
+			{
+				_spritePixelsPerUnit = EditorPrefs.GetFloat(PREFS_PREFIX + "spritePixelsPerUnit");
+			}
+			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteTargetObjectType"))
+			{
+				_targetObjectType = (AnimationTargetObjectType)EditorPrefs.GetInt(PREFS_PREFIX + "spriteTargetObjectType");
+			}
+			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignment"))
+			{
+				_spriteAlignment = (SpriteAlignment)EditorPrefs.GetInt(PREFS_PREFIX + "spriteAlignment");
+			}
+			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignmentCustomX"))
+			{
+				_spriteAlignmentCustomX = EditorPrefs.GetFloat(PREFS_PREFIX + "spriteAlignmentCustomX");
+			}
+			if (EditorPrefs.HasKey(PREFS_PREFIX + "spriteAlignmentCustomY"))
+			{
+				_spriteAlignmentCustomY = EditorPrefs.GetFloat(PREFS_PREFIX + "spriteAlignmentCustomY");
+			}
+
+			if (EditorPrefs.HasKey(PREFS_PREFIX + "saveSpritesToSubfolder"))
+			{
+				_saveSpritesToSubfolder = EditorPrefs.GetBool(PREFS_PREFIX + "saveSpritesToSubfolder");
+			}
+			if (EditorPrefs.HasKey(PREFS_PREFIX + "saveAnimationsToSubfolder"))
+			{
+				_saveAnimationsToSubfolder = EditorPrefs.GetBool(PREFS_PREFIX + "saveAnimationsToSubfolder");
+			}
+			if (EditorPrefs.HasKey(PREFS_PREFIX + "automaticImporting"))
+			{
+				_automaticImporting = EditorPrefs.GetBool(PREFS_PREFIX + "automaticImporting");
+			}
+
+			// Find all nonLoopingClip Prefences, load them into the sharedData.
+			int numOldClips = 0;
+			string loopCountKey = PREFS_PREFIX + "nonLoopCount";
+			if (EditorPrefs.HasKey(loopCountKey))
+			{
+				numOldClips = EditorPrefs.GetInt(loopCountKey);
+			}
+
+			for (int i = 0; i < numOldClips; ++i)
+			{
+				string clipKey = PREFS_PREFIX + "nonLoopCount" + i.ToString();
+
+				// If the clip hasn't already been moved to the shared data, do it now.
+				if (EditorPrefs.HasKey(clipKey))
+				{
+					var stringAtKey = EditorPrefs.GetString(clipKey);
+					if (!_animationNamesThatDoNotLoop.Contains(stringAtKey))
+					{
+						_animationNamesThatDoNotLoop.Add(stringAtKey);
+					}
+				}
+			}
+		}
+	}
+}

--- a/Assets/AnimationImporter/Editor/AnimationImporterSharedConfig.cs.meta
+++ b/Assets/AnimationImporter/Editor/AnimationImporterSharedConfig.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5d52663f1e64b4a539cad6cb8f3e65ed
+timeCreated: 1469159431
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnimationImporter/Editor/AnimationImporterWindow.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporterWindow.cs
@@ -45,7 +45,7 @@ namespace AnimationImporter
 
 		public void OnEnable()
 		{
-			importer.LoadUserConfig();
+			importer.LoadOrCreateUserConfig();
 		}
 
 		public void OnGUI()
@@ -91,6 +91,17 @@ namespace AnimationImporter
 				Aseprite Application
 			*/
 
+			// Show a button for allowing users to upgrade their config from Preferences to a saved asset
+			if (importer.sharedData.UserHasOldPreferences())
+			{
+				if (GUILayout.Button("Copy Config From Old Preferences"))
+				{
+					importer.sharedData.CopyFromPreferences();
+				}
+
+				EditorGUILayout.Space();
+			}
+
 			GUILayout.BeginHorizontal();
 			GUILayout.Label("Aseprite Application Path");
 
@@ -125,29 +136,29 @@ namespace AnimationImporter
 				sprite values
 			*/
 
-			importer.targetObjectType = (AnimationTargetObjectType)EditorGUILayout.EnumPopup("Target Object", importer.targetObjectType);
+			importer.sharedData.targetObjectType = (AnimationTargetObjectType)EditorGUILayout.EnumPopup("Target Object", importer.sharedData.targetObjectType);
 
-			importer.spriteAlignment = (SpriteAlignment)EditorGUILayout.EnumPopup("Sprite Alignment", importer.spriteAlignment);
+			importer.sharedData.spriteAlignment = (SpriteAlignment)EditorGUILayout.EnumPopup("Sprite Alignment", importer.sharedData.spriteAlignment);
 
-			if (importer.spriteAlignment == SpriteAlignment.Custom)
+			if (importer.sharedData.spriteAlignment == SpriteAlignment.Custom)
 			{
-				importer.spriteAlignmentCustomX = EditorGUILayout.Slider("x", importer.spriteAlignmentCustomX, 0, 1f);
-				importer.spriteAlignmentCustomY = EditorGUILayout.Slider("y", importer.spriteAlignmentCustomY, 0, 1f);
+				importer.sharedData.spriteAlignmentCustomX = EditorGUILayout.Slider("x", importer.sharedData.spriteAlignmentCustomX, 0, 1f);
+				importer.sharedData.spriteAlignmentCustomY = EditorGUILayout.Slider("y", importer.sharedData.spriteAlignmentCustomY, 0, 1f);
 			}
 
-			importer.spritePixelsPerUnit = EditorGUILayout.FloatField("Sprite Pixels per Unit", importer.spritePixelsPerUnit);
+			importer.sharedData.spritePixelsPerUnit = EditorGUILayout.FloatField("Sprite Pixels per Unit", importer.sharedData.spritePixelsPerUnit);
 
 			EditorGUILayout.BeginHorizontal();
-			importer.saveSpritesToSubfolder = EditorGUILayout.Toggle("Sprites to Subfolder", importer.saveSpritesToSubfolder);
+			importer.sharedData.saveSpritesToSubfolder = EditorGUILayout.Toggle("Sprites to Subfolder", importer.sharedData.saveSpritesToSubfolder);
 
-			importer.saveAnimationsToSubfolder = EditorGUILayout.Toggle("Animations to Subfolder", importer.saveAnimationsToSubfolder);
+			importer.sharedData.saveAnimationsToSubfolder = EditorGUILayout.Toggle("Animations to Subfolder", importer.sharedData.saveAnimationsToSubfolder);
 			EditorGUILayout.EndHorizontal();
 
 			GUILayout.Space(25f);
 
 			ShowHeadline("Automatic Import");
 			EditorGUILayout.BeginHorizontal();
-			importer.automaticImporting = EditorGUILayout.Toggle("Automatic Import", importer.automaticImporting);
+			importer.sharedData.automaticImporting = EditorGUILayout.Toggle("Automatic Import", importer.sharedData.automaticImporting);
 			EditorGUILayout.LabelField("Use at your own risk!", EditorStyles.boldLabel);
 			EditorGUILayout.EndHorizontal();
 			EditorGUILayout.LabelField("Looks for existing Controller with same name. Uses current import setting.");
@@ -159,15 +170,15 @@ namespace AnimationImporter
 			GUILayout.Space(25f);
 			ShowHeadline("Non-looping Animations");
 
-			for (int i = 0; i < importer.animationNamesThatDoNotLoop.Count; i++)
+			for (int i = 0; i < importer.sharedData.animationNamesThatDoNotLoop.Count; i++)
 			{
 				GUILayout.BeginHorizontal();
-				GUILayout.Label(importer.animationNamesThatDoNotLoop[i]);
+				GUILayout.Label(importer.sharedData.animationNamesThatDoNotLoop[i]);
 				bool doDelete = GUILayout.Button("Delete");			
 				GUILayout.EndHorizontal();
 				if (doDelete)
 				{
-					importer.RemoveAnimationThatDoesNotLoop(i);
+					importer.sharedData.RemoveAnimationThatDoesNotLoop(i);
 					break;
 				}
 			}
@@ -179,12 +190,17 @@ namespace AnimationImporter
 			_nonLoopingAnimationEnterValue = EditorGUILayout.TextField(_nonLoopingAnimationEnterValue);
 			if (GUILayout.Button("Enter"))
 			{
-				if (importer.AddAnimationThatDoesNotLoop(_nonLoopingAnimationEnterValue))
+				if (importer.sharedData.AddAnimationThatDoesNotLoop(_nonLoopingAnimationEnterValue))
 				{
 					_nonLoopingAnimationEnterValue = "";
 				}
 			}
 			GUILayout.EndHorizontal();
+
+			if (GUI.changed) 
+			{
+				EditorUtility.SetDirty(importer.sharedData);
+			}
 		}
 
 		private void ShowAnimationsGUI()

--- a/Assets/AnimationImporter/Editor/AssetDatabaseUtility.cs
+++ b/Assets/AnimationImporter/Editor/AssetDatabaseUtility.cs
@@ -1,0 +1,88 @@
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+namespace AnimationImporter
+{
+	/// <summary>
+	/// Utilities for Unity's built in AssetDatabase class
+	/// </summary>
+	public static class AssetDatabaseUtility
+	{
+		public const char UnityDirectorySeparator = '/';
+		public const string ResourcesFolderName = "Resources";
+
+		/// <summary>
+		/// Creates the asset and any directories that are missing along its path.
+		/// </summary>
+		/// <param name="unityObject">UnityObject to create an asset for.</param>
+		/// <param name="unityFilePath">Unity file path (e.g. "Assets/Resources/MyFile.asset".</param>
+		public static void CreateAssetAndDirectories(UnityEngine.Object unityObject, string unityFilePath)
+		{
+			var pathDirectory = Path.GetDirectoryName(unityFilePath) + UnityDirectorySeparator;
+			AssetDatabaseUtility.CreateDirectoriesInPath(pathDirectory);
+
+			AssetDatabase.CreateAsset(unityObject, unityFilePath);
+		}
+
+		private static void CreateDirectoriesInPath(string unityDirectoryPath)
+		{
+			// Check that last character is a directory separator
+			if (unityDirectoryPath[unityDirectoryPath.Length - 1] != UnityDirectorySeparator)
+			{
+				var warningMessage = string.Format(
+					                     "Path supplied to CreateDirectoriesInPath that does not include a DirectorySeparator " +
+					                     "as the last character." +
+					                     "\nSupplied Path: {0}, Filename: {1}",
+					                     unityDirectoryPath);
+				Debug.LogWarning(warningMessage);
+			}
+
+			// Warn and strip filenames
+			var filename = Path.GetFileName(unityDirectoryPath);
+			if (!string.IsNullOrEmpty(filename))
+			{
+				var warningMessage = string.Format(
+					                     "Path supplied to CreateDirectoriesInPath that appears to include a filename. It will be " +
+					                     "stripped. A path that ends with a DirectorySeparate should be supplied. " +
+					                     "\nSupplied Path: {0}, Filename: {1}",
+					                     unityDirectoryPath,
+					                     filename);
+				Debug.LogWarning(warningMessage);
+
+				unityDirectoryPath = unityDirectoryPath.Replace(filename, string.Empty);
+			}
+
+			var folders = unityDirectoryPath.Split(UnityDirectorySeparator);
+
+			// Error if path does NOT start from Assets
+			if (folders.Length > 0 && folders[0] != "Assets")
+			{
+				var exceptionMessage = "AssetDatabaseUtility CreateDirectoriesInPath expects full Unity path, including 'Assets\\\". " +
+				                       "Adding Assets to path.";
+				throw new UnityException(exceptionMessage);
+			}
+
+			string pathToFolder = string.Empty;
+			foreach (var folder in folders)
+			{
+				// Don't check for or create empty folders
+				if (string.IsNullOrEmpty(folder))
+				{
+					continue;
+				}
+
+				// Create folders that don't exist
+				pathToFolder = string.Concat(pathToFolder, folder);
+				if (!UnityEditor.AssetDatabase.IsValidFolder(pathToFolder))
+				{
+					var pathToParent = System.IO.Directory.GetParent(pathToFolder).ToString();
+					AssetDatabase.CreateFolder(pathToParent, folder);
+					AssetDatabase.Refresh();
+				}
+
+				pathToFolder = string.Concat(pathToFolder, UnityDirectorySeparator);
+			}
+		}
+	}
+}

--- a/Assets/AnimationImporter/Editor/AssetDatabaseUtility.cs.meta
+++ b/Assets/AnimationImporter/Editor/AssetDatabaseUtility.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9011cd088bbf74886a315fcd8b8908af
+timeCreated: 1469158918
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnimationImporter/Editor/ScriptableObjectUtility.cs
+++ b/Assets/AnimationImporter/Editor/ScriptableObjectUtility.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace AnimationImporter
+{
+	/// <summary>
+	/// Utility functions for ScriptableObjects.
+	/// </summary>
+	public static class ScriptableObjectUtility
+	{
+		/// <summary>
+		/// Loads the save data from a Unity relative path. Returns null if the data doesn't exist.
+		/// </summary>
+		/// <returns>The saved data as a ScriptableObject, or null if not found.</returns>
+		/// <param name="unityPathToFile">Unity path to file (e.g. "Assets/Resources/MyFile.asset")</param>
+		/// <typeparam name="T">The ScriptableObject type</typeparam>
+		public static T LoadSaveData<T> (string unityPathToFile) where T : ScriptableObject
+		{
+			// Path must contain Resources folder
+			var resourcesFolder = string.Concat(
+				AssetDatabaseUtility.UnityDirectorySeparator,
+				AssetDatabaseUtility.ResourcesFolderName,
+				AssetDatabaseUtility.UnityDirectorySeparator);
+			if (!unityPathToFile.Contains(resourcesFolder))
+			{
+				var exceptionMessage = string.Format(
+					"Failed to Load ScriptableObject of type, {0}, from path: {1}. " +
+					"Path must begin with Assets and include a directory within the Resources folder.",
+					typeof(T).ToString(),
+					unityPathToFile);
+				throw new UnityException(exceptionMessage);
+			}
+
+			// Get Resource relative path - Resource path should only include folders underneath Resources and no file extension
+			var resourceRelativePath = GetResourceRelativePath(unityPathToFile);
+
+			// Remove file extension
+			var fileExtension = System.IO.Path.GetExtension(unityPathToFile);
+			resourceRelativePath = resourceRelativePath.Replace(fileExtension, string.Empty);
+
+			return Resources.Load<T>(resourceRelativePath);
+		}
+
+		/// <summary>
+		/// Loads the saved data, stored as a ScriptableObject at the specified path. If the file or folders don't exist,
+		/// it creates them.
+		/// </summary>
+		/// <returns>The saved data as a ScriptableObject.</returns>
+		/// <param name="unityPathToFile">Unity path to file (e.g. "Assets/Resources/MyFile.asset")</param>
+		/// <typeparam name="T">The ScriptableObject type</typeparam>
+		public static T LoadOrCreateSaveData<T>(string unityPathToFile) where T : ScriptableObject
+		{
+			var loadedSettings = LoadSaveData<T>(unityPathToFile);
+			if (loadedSettings == null)
+			{
+				loadedSettings = ScriptableObject.CreateInstance<T>();
+				AssetDatabaseUtility.CreateAssetAndDirectories(loadedSettings, unityPathToFile);
+			}
+
+			return loadedSettings;
+		}
+
+		private static string GetResourceRelativePath(string unityPath)
+		{
+			var resourcesFolder = AssetDatabaseUtility.ResourcesFolderName + AssetDatabaseUtility.UnityDirectorySeparator;
+			var pathToResources = unityPath.Substring(0, unityPath.IndexOf(resourcesFolder));
+
+			// Remove all folders leading up to the Resources folder
+			pathToResources = unityPath.Replace(pathToResources, string.Empty);
+
+			// Remove the Resources folder
+			pathToResources = pathToResources.Replace(resourcesFolder, string.Empty);
+
+			return pathToResources;
+		}
+	}
+}

--- a/Assets/AnimationImporter/Editor/ScriptableObjectUtility.cs.meta
+++ b/Assets/AnimationImporter/Editor/ScriptableObjectUtility.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e5bf0ea2b912b41b080813f3672f7d45
+timeCreated: 1469158915
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This should fully address issue #5. It uses a ScriptableObject to store most of the old config values, with the exception of AsepritePath (which is user specific) and AnimationController for OverrideController mode (which is more of just a convenience that it remembers the last used Controller, so again, user specific). The ScriptableObject is an asset that's in the repository, so it can be shared between users and moved between projects.

This change moves most of the properties on AnimationImporter into the ScriptableObject, called SharedConfig (or SharedData). When AnimationImporter Loads its config, it will try to automatically create the ScriptableObject if not found. I allowed most things to just reach in and check the config - I'm sure this could be made a bit safer, but it was the easiest fix for now. Note though that during AssetPostprocessing it will not create the saved config if it doesn't exist, or else it tries to create a new config when importing an existing config.

It uses a few new utility libraries that we use at Red Blue - ScriptableObjectUtility for creating the SharedConfig file, and AssetDatabaseUtility for quickly creating all directories along the path to the SharedConfig.

I also included some ability to upgrade to this version through a button that copies Preferences into the SharedConfig file. It doesn't delete the preferences, so that you can always recover them. This is almost entirely just for you @talecrafter, since I figure you've probably added a lot of nonLoopingClips and don't want to reenter them. It could be deleted once we are all upgraded.
