### PR TITLE
Unity 5.6 changes

### DIFF
--- a/Assets/AnimationImporter/Editor/AnimationImporter.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporter.cs
@@ -372,6 +372,7 @@ namespace AnimationImporter
 				overrideController.runtimeAnimatorController = baseController;
 
 				// set override clips
+#if UNITY_5_6_OR_NEWER
 				var clipPairs = new List<KeyValuePair<AnimationClip, AnimationClip>>(overrideController.overridesCount);
 				overrideController.GetOverrides(clipPairs);
 
@@ -381,6 +382,17 @@ namespace AnimationImporter
 					AnimationClip clip = animations.GetClipOrSimilar(animationName);
 					overrideController[animationName] = clip;
 				}
+#else
+				var clipPairs = overrideController.clips;
+				for (int i = 0; i < clipPairs.Length; i++)
+				{
+					string animationName = clipPairs[i].originalClip.name;
+					AnimationClip clip = animations.GetClipOrSimilar(animationName);
+					clipPairs[i].overrideClip = clip;
+				}
+				overrideController.clips = clipPairs;
+#endif
+
 				EditorUtility.SetDirty(overrideController);
 			}
 			else

--- a/Assets/AnimationImporter/Editor/AnimationImporter.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporter.cs
@@ -372,15 +372,15 @@ namespace AnimationImporter
 				overrideController.runtimeAnimatorController = baseController;
 
 				// set override clips
-				var clipPairs = overrideController.clips;
-				for (int i = 0; i < clipPairs.Length; i++)
-				{
-					string animationName = clipPairs[i].originalClip.name;
-					AnimationClip clip = animations.GetClipOrSimilar(animationName);
-					clipPairs[i].overrideClip = clip;
-				}
-				overrideController.clips = clipPairs;
+				var clipPairs = new List<KeyValuePair<AnimationClip, AnimationClip>>(overrideController.overridesCount);
+				overrideController.GetOverrides(clipPairs);
 
+				foreach (var pair in clipPairs)
+				{
+					string animationName = pair.Key.name;
+					AnimationClip clip = animations.GetClipOrSimilar(animationName);
+					overrideController[animationName] = clip;
+				}
 				EditorUtility.SetDirty(overrideController);
 			}
 			else

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pixelart Animation Importer for Unity
 This tool is an Aseprite and PyxelEdit Animation Importer for Unity.
 It's already used in several projects and should work for most use cases. There is no guaranteed support though, so test and use this at your own will.
 
-Tested with: Unity 5.5, Aseprite 1.1.13, PyxelEdit 0.4.3
+Tested with: Unity 5.6, Aseprite 1.1.13, PyxelEdit 0.4.3
 
 
 Setup


### PR DESCRIPTION
Updated to work with Unity 5.6. AnimatorOverrideController is now deprecated and throws warnings. It has been replaced with a call to AnimatorOverrideController.GetOverrides().