### PR TITLE
Override looping flag for existing clips on import

### DIFF
--- a/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimationSheet.cs
+++ b/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimationSheet.cs
@@ -113,7 +113,6 @@ namespace AnimationImporter
 			{
 				// get previous animation settings
 				targetType = PreviousImportSettings.GetAnimationTargetFromExistingClip(clip);
-				isLooping = clip.isLooping;
 			}
 			else
 			{


### PR DESCRIPTION
This PR addresses Issue #19. Like I said, I understand it's subjective, and it is clearly your intent to preserve looping and Targets of existing clips.