### PR TITLE
Add app extension for macOS

### DIFF
--- a/Assets/AnimationImporter/Editor/AnimationImporterWindow.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporterWindow.cs
@@ -270,7 +270,7 @@ namespace AnimationImporter
 				var path = EditorUtility.OpenFilePanel(
 					"Select Aseprite Application",
 					"",
-					"exe");
+					"exe,app");
 				if (!string.IsNullOrEmpty(path))
 				{
 					newPath = path;


### PR DESCRIPTION
Add extension `app` to `Select Aseprite application dialog` for macOS

For #24 