### PR TITLE
Support for playback direction when importing aseprite files

### DIFF
--- a/Assets/AnimationImporter/Editor/Aseprite/AsepriteImporter.cs
+++ b/Assets/AnimationImporter/Editor/Aseprite/AsepriteImporter.cs
@@ -254,6 +254,19 @@ namespace AnimationImporter.Aseprite
 				anim.firstSpriteIndex = (int)(frameTag["from"].Number);
 				anim.lastSpriteIndex = (int)(frameTag["to"].Number);
 
+				switch (frameTag["direction"].Str)
+				{
+					default:
+						anim.direction = PlaybackDirection.Forward;
+						break;
+					case "reverse":
+						anim.direction = PlaybackDirection.Reverse;
+						break;
+					case "pingpong":
+						anim.direction = PlaybackDirection.PingPong;
+						break;
+				}
+
 				animationSheet.animations.Add(anim);
 			}
 

--- a/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimation.cs
+++ b/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimation.cs
@@ -1,9 +1,18 @@
 ﻿using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
+using System;
+using System.Linq;
 
 namespace AnimationImporter
 {
+	public enum PlaybackDirection
+	{
+		Forward, // default
+		Reverse, // reversed frames
+		PingPong // forward, then reverse
+	}
+
 	public class ImportedAnimation
 	{
 		public string name;
@@ -23,6 +32,9 @@ namespace AnimationImporter
 		public int firstSpriteIndex;
 		public int lastSpriteIndex;
 
+		// unity animations only play forward, so this will affect the way frames are added to the final animation clip
+		public PlaybackDirection direction;
+
 		// used with the indices because we to not have the Frame array yet
 		public int Count
 		{
@@ -36,5 +48,24 @@ namespace AnimationImporter
 		//  public methods
 		// --------------------------------------------------------------------------------
 
+		/// <summary>
+		/// Lists frames so that the final anim seems to play in the desired direction.
+		/// *Attention:* Can return more than <see cref="Count"/> frames. 
+		/// </summary>
+		public IEnumerable<ImportedAnimationFrame> ListFramesAccountingForPlaybackDirection()
+		{
+			switch (direction)
+			{
+				default:
+				case PlaybackDirection.Forward: // ex: 1, 2, 3, 4
+					return frames;
+
+				case PlaybackDirection.Reverse: // ex: 4, 3, 2, 1
+					return frames.Reverse();
+
+				case PlaybackDirection.PingPong: // ex: 1, 2, 3, 4, 3, 2
+					return frames.Concat(frames.Skip(1).Take(frames.Length - 2).Reverse());
+			}
+		}
 	}
 }

--- a/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimation.cs
+++ b/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimation.cs
@@ -12,9 +12,6 @@ namespace AnimationImporter
 
 		public bool isLooping = true;
 
-		// duration of each frame
-		private List<float> timings = null;
-
 		// final animation clip; saved here for usage when building the AnimatorController
 		public AnimationClip animationClip;
 
@@ -39,45 +36,5 @@ namespace AnimationImporter
 		//  public methods
 		// --------------------------------------------------------------------------------
 
-		public void SetFrames(ImportedAnimationFrame[] frames)
-		{
-			this.frames = frames;
-
-			CalculateKeyFrameTimings();
-		}
-
-		// ================================================================================
-		//  Key Frames
-		// --------------------------------------------------------------------------------
-
-		public float GetKeyFrameTime(int i)
-		{
-			return timings[i];
-		}
-
-		public float GetLastKeyFrameTime(float frameRate)
-		{
-			float timePoint = GetKeyFrameTime(Count);
-			timePoint -= (1f / frameRate);
-
-			return timePoint;
-		}
-
-		private void CalculateKeyFrameTimings()
-		{
-			float timeCount;
-			timings = new List<float>();
-
-			// first sprite will be set at the beginning of the animation
-			timeCount = 0;
-			timings.Add(timeCount);
-
-			for (int k = 0; k < frames.Length; k++)
-			{
-				// add duration of frame in seconds
-				timeCount += frames[k].duration / 1000f;
-				timings.Add(timeCount);
-			}
-		}
 	}
 }

--- a/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimationSheet.cs
+++ b/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimationSheet.cs
@@ -133,7 +133,7 @@ namespace AnimationImporter
 			}
 
 			// convert keyframes
-			ImportedAnimationFrame[] srcKeyframes = anim.frames;
+			ImportedAnimationFrame[] srcKeyframes = anim.ListFramesAccountingForPlaybackDirection().ToArray();
 			ObjectReferenceKeyframe[] keyFrames = new ObjectReferenceKeyframe[srcKeyframes.Length + 1];
 			float timeOffset = 0f;
 

--- a/Assets/AnimationImporter/Editor/PyxelEdit/PyxelEditImporter.cs
+++ b/Assets/AnimationImporter/Editor/PyxelEdit/PyxelEditImporter.cs
@@ -149,7 +149,7 @@ namespace AnimationImporter.PyxelEdit
 					frames[frameIndex] = frame;
 				}
 
-				importAnimation.SetFrames(frames);
+				importAnimation.frames = frames;
 
 				animationSheet.animations.Add(importAnimation);
 			}


### PR DESCRIPTION
### Summary
In Aseprite, animations have an attribute *direction* that changes the way they get played.
While it's very helpful (*pingpong* especially), it's not taken into account when imported into Unity, making for tedious animation hand-editing, either in Aseprite or Unity.

I made changes to support that feature, and tested it a bit on my project.

### Details

In the first commit, I removed the frame timings precomputation, because it was not necessary; and while it worked well for normal playback, it would have needed to be adapted for *reverse* and *pingpong*.

In the second commit, I added an attribute in `ImportedAnimation` that's set during parse in `AsepriteImporter`, and read when during conversion to a Unity anim.