### PR TITLE
added error popup when an asset is imported but aseprite path is improperly configured

### DIFF
--- a/Assets/AnimationImporter/Editor/AnimationImporter.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporter.cs
@@ -541,6 +541,33 @@ namespace AnimationImporter
 			return false;
 		}
 
+		// check if there is a configured importer for the specified extension
+		public static bool IsConfiguredForAssets(DefaultAsset[] assets)
+		{
+			foreach(var asset in assets)
+			{
+				string assetPath = AssetDatabase.GetAssetPath(asset);
+				string extension = GetExtension(assetPath);
+
+				if (!string.IsNullOrEmpty(assetPath))
+				{
+					if (_importerPlugins.ContainsKey(extension))
+					{
+						IAnimationImporterPlugin importer = _importerPlugins[extension];
+						if (importer != null)
+						{
+							if(!importer.IsConfigured())
+							{
+								return false;
+							}
+						}
+					}
+				}
+			}
+
+			return true;
+		}
+
 		private static string GetExtension(string path)
 		{
 			if (string.IsNullOrEmpty(path))

--- a/Assets/AnimationImporter/Editor/AnimationImporterWindow.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporterWindow.cs
@@ -287,6 +287,13 @@ namespace AnimationImporter
 			importer.asepritePath = GUILayout.TextField(newPath, GUILayout.MaxWidth(300f));
 
 			GUILayout.EndHorizontal();
+
+			if(!File.Exists(AnimationImporter.Instance.asepritePath))
+			{
+				var fileErrorMessage = string.Format(
+					"Cannot find Aseprite at the specified path. Use the Select button to locate the application.");
+				EditorGUILayout.HelpBox(fileErrorMessage, MessageType.Warning);
+			}
 		}
 
 		private void ShowAnimationsGUI()
@@ -296,7 +303,7 @@ namespace AnimationImporter
 			DefaultAsset[] droppedAssets = ShowDropButton<DefaultAsset>(importer.canImportAnimations, AnimationImporter.IsValidAsset);
 			if (droppedAssets != null && droppedAssets.Length > 0)
 			{
-				importer.ImportAssets(droppedAssets);
+				ImportAssetsOrError(droppedAssets);
 			}
 		}
 
@@ -307,7 +314,7 @@ namespace AnimationImporter
 			DefaultAsset[] droppedAssets = ShowDropButton<DefaultAsset>(importer.canImportAnimations, AnimationImporter.IsValidAsset);
 			if (droppedAssets != null && droppedAssets.Length > 0)
 			{
-				importer.ImportAssets(droppedAssets, ImportAnimatorController.AnimatorController);
+				ImportAssetsOrError(droppedAssets, ImportAnimatorController.AnimatorController);
 			}
 		}
 
@@ -320,8 +327,28 @@ namespace AnimationImporter
 			DefaultAsset[] droppedAssets = ShowDropButton<DefaultAsset>(importer.canImportAnimationsForOverrideController, AnimationImporter.IsValidAsset);
 			if (droppedAssets != null && droppedAssets.Length > 0)
 			{
-				importer.ImportAssets(droppedAssets, ImportAnimatorController.AnimatorOverrideController);
+				ImportAssetsOrError(droppedAssets, ImportAnimatorController.AnimatorOverrideController);
 			}
+		}
+
+		private void ImportAssetsOrError(DefaultAsset[] assets, ImportAnimatorController importAnimatorController = ImportAnimatorController.None)
+		{
+			if(AnimationImporter.IsConfiguredForAssets(assets))
+			{
+				importer.ImportAssets(assets, importAnimatorController);
+			}
+			else
+			{
+				ShowPopupForBadAsepritePath(assets[0].name);
+			}
+		}
+
+		private void ShowPopupForBadAsepritePath(string assetName)
+		{
+			var message = string.Format(
+				"Cannot import Aseprite file \"{0}\" because the application cannot be found at the configured path. Use the Select button in the Config section to locate Aseprite.",
+				assetName);
+			EditorUtility.DisplayDialog("Error", message, "Ok");
 		}
 
 		private void ShowHeadline(string headline)

--- a/Assets/AnimationImporter/Editor/Aseprite/AsepriteImporter.cs
+++ b/Assets/AnimationImporter/Editor/Aseprite/AsepriteImporter.cs
@@ -64,8 +64,12 @@ namespace AnimationImporter.Aseprite
 
 		public bool IsValid()
 		{
-			return AnimationImporter.Instance != null && AnimationImporter.Instance.sharedData != null
-				&& File.Exists(AnimationImporter.Instance.asepritePath);
+			return AnimationImporter.Instance != null && AnimationImporter.Instance.sharedData != null;
+		}
+
+		public bool IsConfigured()
+		{
+			return File.Exists(AnimationImporter.Instance.asepritePath);
 		}
 
 		// ================================================================================

--- a/Assets/AnimationImporter/Editor/IAnimationImporterPlugin.cs
+++ b/Assets/AnimationImporter/Editor/IAnimationImporterPlugin.cs
@@ -9,5 +9,6 @@ namespace AnimationImporter
 	{
 		ImportedAnimationSheet Import(AnimationImportJob job, AnimationImporterSharedConfig config);
 		bool IsValid();
+		bool IsConfigured();
 	}
 }

--- a/Assets/AnimationImporter/Editor/PyxelEdit/PyxelEditImporter.cs
+++ b/Assets/AnimationImporter/Editor/PyxelEdit/PyxelEditImporter.cs
@@ -39,6 +39,11 @@ namespace AnimationImporter.PyxelEdit
 			return IonicZipDllIsPresent();
 		}
 
+		public bool IsConfigured()
+		{
+			return true;
+		}
+
 		private static bool ImportImageAndMetaInfo(AnimationImportJob job)
 		{
 			_latestData = null;


### PR DESCRIPTION
This addresses the issue I submitted #28.

Some info about my change:
* The Popup assumes that if the Importer.IsConfigured() test fails, it's because Aseprite wasn't linked. This might be a problem in the future if other import plugins require alternative tests.
* The only elegant way I could see to test for the file was to add the IsConfigured function to the IAnimationImporterPlugin. Please feel free to rework this or suggest another change.
* There could easily be some other things I didn't consider with .pyxel files. **I did not test this with PyxelEdit**
* You may not like the warning HelpBox when Aseprite path is not setup, as some users just won't use Aseprite. I made it a Warning (not error) for this reason, but it still may be intrusive.

Here's a gif of the new behavior.

![animation-importer-badpath-fix](https://user-images.githubusercontent.com/398377/46331199-a79b7a80-c5e4-11e8-9336-b08e424d1c1f.gif)