### PR TITLE
Fixed serialization of naming scheme preference

### DIFF
--- a/Assets/AnimationImporter/Editor/Config/AnimationImporterSharedConfig.cs
+++ b/Assets/AnimationImporter/Editor/Config/AnimationImporterSharedConfig.cs
@@ -122,6 +122,7 @@ namespace AnimationImporter
 			set { _animationControllersTargetLocation = value; }
 		}
 
+		[SerializeField]
 		private SpriteNamingScheme _spriteNamingScheme = SpriteNamingScheme.Classic;
 		public SpriteNamingScheme spriteNamingScheme
 		{


### PR DESCRIPTION
Naming scheme preference was not pertained between Unity sessions, the field `_spriteNamingScheme` was not serialized in `AnimationImporterSharedConfig.cs`, fixed by adding `[SerializeField]` before it.