### PR TITLE
33 Unity Package for Custom Package Import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ ExportedObj
 *.user
 *.unityproj
 *.booproj
+*.idea
  
 
 # OS generated

--- a/Assets/AnimationImporter/Editor/com.talecrafter.animationimporter.Editor.asmdef
+++ b/Assets/AnimationImporter/Editor/com.talecrafter.animationimporter.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "com.talecrafter.animationimporter.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:ba3c18ee443f5fc428ce11b0dc16eb4b"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/AnimationImporter/Editor/com.talecrafter.animationimporter.Editor.asmdef.meta
+++ b/Assets/AnimationImporter/Editor/com.talecrafter.animationimporter.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bad09595db0004c4d93ef6d5df9efa50
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/com.talecrafter.animationimporter.asmdef
+++ b/Assets/com.talecrafter.animationimporter.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "com.talecrafter.animationimporter"
+}

--- a/Assets/com.talecrafter.animationimporter.asmdef.meta
+++ b/Assets/com.talecrafter.animationimporter.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ba3c18ee443f5fc428ce11b0dc16eb4b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "com.talecrafter.animationimporter",
+    "version": "1.4.0",
+    "displayName": "Animation Importer",
+    "unity": "2020.2",
+    "description": "An Aseprite and PyxelEdit Animation Importer for Unity",
+    "hideInEditor": false
+  }

--- a/Assets/package.json.meta
+++ b/Assets/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8df2ff17db018b7408abc9a3610d8a8e
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@ It's already used in several projects and should work for most use cases. There 
 Tested with: Unity 5.6, Aseprite 1.1.13, PyxelEdit 0.4.3
 
 
+Installation
+-----
+
+This extension can be installed using Unity package manager.  
+`https://github.com/talecrafter/AnimationImporter.git?path=/Assets`  
+
+* Package manager UI  
+
+	![screenshot](https://user-images.githubusercontent.com/6723783/72479980-c9554c80-37aa-11ea-8fd8-978d3fa860bd.png)
+
+* Manifest
+```
+{
+	"dependencies": {
+		"com.talecrafter.animationimporter": "https://github.com/talecrafter/AnimationImporter.git?path=/Assets"
+	}
+}
+```
+
+Or by importing the content of `Assets` into the `Plugins` folder in Unity.
+
 Setup
 -----
 


### PR DESCRIPTION
Implements setting up the repo as a unity package as asked in #33.

To permit the use of the same folder structure as now, package needs to be added with the Assets path referenced: `https://github.com/talecrafter/AnimationImporter.git?path=/Assets`
