### PR TITLE
Add support for custom sample frame rate

### DIFF
--- a/Assets/AnimationImporter/Editor/AnimationImporter.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporter.cs
@@ -439,7 +439,7 @@ namespace AnimationImporter
 
 			foreach (var animation in animationInfo.animations)
 			{
-				animationInfo.CreateAnimation(animation, pathForAnimations, masterName, sharedData.targetObjectType, sharedData.pathToSpriteRendererComponent, sharedData.pathToImageComponent);
+				animationInfo.CreateAnimation(animation, pathForAnimations, masterName, sharedData.targetObjectType, sharedData.pathToSpriteRendererComponent, sharedData.pathToImageComponent, sharedData.animationFrameRate);
 			}
 		}
 

--- a/Assets/AnimationImporter/Editor/AnimationImporterWindow.cs
+++ b/Assets/AnimationImporter/Editor/AnimationImporterWindow.cs
@@ -168,6 +168,8 @@ namespace AnimationImporter
 
 			importer.sharedData.spritePixelsPerUnit = EditorGUILayout.FloatField("Sprite Pixels per Unit", importer.sharedData.spritePixelsPerUnit);
 
+			importer.sharedData.animationFrameRate = EditorGUILayout.FloatField("Animation Sample Frames", importer.sharedData.animationFrameRate);
+
 			GUILayout.Space(5f);
 
 			ShowTargetLocationOptions("Sprites", importer.sharedData.spritesTargetLocation);

--- a/Assets/AnimationImporter/Editor/Config/AnimationImporterSharedConfig.cs
+++ b/Assets/AnimationImporter/Editor/Config/AnimationImporterSharedConfig.cs
@@ -44,6 +44,20 @@ namespace AnimationImporter
 		}
 
 		[SerializeField]
+		private float _animationFrameRate = 60f;
+		public float animationFrameRate
+        {
+            get
+            {
+				return _animationFrameRate;
+            }
+            set
+            {
+				_animationFrameRate = value;
+            }
+        }
+
+		[SerializeField]
 		private pivotAlignmentType _pivotAlignmentType = pivotAlignmentType.Normalized;
 		public pivotAlignmentType pivotAlignmentType
 		{

--- a/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimationSheet.cs
+++ b/Assets/AnimationImporter/Editor/ImportedData/ImportedAnimationSheet.cs
@@ -101,7 +101,7 @@ namespace AnimationImporter
 			return null;
 		}
 
-		public void CreateAnimation(ImportedAnimation anim, string basePath, string masterName, AnimationTargetObjectType targetType, string spriteRendererComponentPath, string imageComponentPath)
+		public void CreateAnimation(ImportedAnimation anim, string basePath, string masterName, AnimationTargetObjectType targetType, string spriteRendererComponentPath, string imageComponentPath, float frameRate)
 		{
 			AnimationClip clip;
 			string fileName = basePath + "/" + masterName + "_" + anim.name + ".anim";
@@ -134,6 +134,8 @@ namespace AnimationImporter
 				clip.wrapMode = WrapMode.Clamp;
 				clip.SetLoop(false);
 			}
+
+			clip.frameRate = frameRate;
 
 			// convert keyframes
 			ImportedAnimationFrame[] srcKeyframes = anim.ListFramesAccountingForPlaybackDirection().ToArray();


### PR DESCRIPTION
## What
Added support for choosing a custom sample rate for animations from the Anim Importer Editor Window.
The time differences between keyframes will be affected in the animation clip.
The animation clip sample frame rate value will be updated.

## Use Cases
**Stylistic Choice**
More consistency for an animator who is intentionally aiming for a stylistic choice based on a set FPS.
Redundant in between frames are not needed and are simply waste.

When using a frame based move editor, designers can spend less time scrubbing through empty animation frames when placing hitbox events, sound events and the like.

Less frames can be used for background elements to save processing unneeded frames.

## Considerations
When importing at a lower frame rate the timings will lose precision.
The lower the sample frame rate, the more likely that Aseprite playback and Unity playback will diverge.

## Tests
60FPS
Length: 0.8 seconds
48 Frames

30FPS
Length: 0.8 seconds
24 Frames

12FPS
Length: 0.833 seconds
10 Frames